### PR TITLE
Fixed fieldName in interpreter-setting.json

### DIFF
--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -1,8 +1,8 @@
 [
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "spark",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkInterpreter",
+    "group": "spark",
+    "name": "spark",
+    "className": "org.apache.zeppelin.spark.SparkInterpreter",
     "properties": {
       "spark.executor.memory": {
         "envName": null,
@@ -56,9 +56,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "sql",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkSqlInterpreter",
+    "group": "spark",
+    "name": "sql",
+    "className": "org.apache.zeppelin.spark.SparkSqlInterpreter",
     "properties": {
       "zeppelin.spark.concurrentSQL": {
         "envName": "ZEPPELIN_SPARK_CONCURRENTSQL",
@@ -81,9 +81,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "dep",
-    "interpreterClassName": "org.apache.zeppelin.spark.DepInterpreter",
+    "group": "spark",
+    "name": "dep",
+    "className": "org.apache.zeppelin.spark.DepInterpreter",
     "properties": {
       "zeppelin.dep.localrepo": {
         "envName": "ZEPPELIN_DEP_LOCALREPO",
@@ -100,9 +100,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "pyspark",
-    "interpreterClassName": "org.apache.zeppelin.spark.PySparkInterpreter",
+    "group": "spark",
+    "name": "pyspark",
+    "className": "org.apache.zeppelin.spark.PySparkInterpreter",
     "properties": {
       "zeppelin.pyspark.python": {
         "envName": "PYSPARK_PYTHON",
@@ -113,9 +113,9 @@
     }
   },
   {
-    "interpreterGroup": "spark",
-    "interpreterName": "r",
-    "interpreterClassName": "org.apache.zeppelin.spark.SparkRInterpreter",
+    "group": "spark",
+    "name": "r",
+    "className": "org.apache.zeppelin.spark.SparkRInterpreter",
     "properties": {
       "zeppelin.R.knitr": {
         "envName": "ZEPPELIN_R_KNITR",


### PR DESCRIPTION
It would fix the CI failure and initialize Spark correctly.
